### PR TITLE
Varialbe imageRoleDefName needs quotes

### DIFF
--- a/quickquickstarts/1_Creating_a_Custom_Linux_Shared_Image_Gallery_Image/readme.md
+++ b/quickquickstarts/1_Creating_a_Custom_Linux_Shared_Image_Gallery_Image/readme.md
@@ -113,7 +113,7 @@ az role definition create --role-definition ./aibRoleImageCreation.json
 # grant role definition to the user assigned identity
 az role assignment create \
     --assignee $imgBuilderCliId \
-    --role $imageRoleDefName \
+    --role "$imageRoleDefName" \
     --scope /subscriptions/$subscriptionID/resourceGroups/$sigResourceGroup
 ```
 


### PR DESCRIPTION
As the example pattern has whitespaces 
> imageRoleDefName="Azure Image Builder Image Def"$(date +'%s')
Then when calling that variable we need to use quotes. It was already quoted in other parts of the script, I'm fixing the one left.